### PR TITLE
リクエストを受ける際にクロールしないようにする

### DIFF
--- a/lib/apply/apply.go
+++ b/lib/apply/apply.go
@@ -67,7 +67,7 @@ func doApply(c *cli.Context) error {
 		return err
 	}
 
-	cache.AttachMetaData(examples)
+	cache.AttachMetaData(examples, true)
 	if filterStatusCodeOk {
 		examples = util.FilterStatusCodeOkExamples(examples)
 	}
@@ -79,7 +79,7 @@ func doApply(c *cli.Context) error {
 	}
 
 	targetExamples = util.RemoveNegativeExamples(targetExamples)
-	cache.AttachMetaData(targetExamples)
+	cache.AttachMetaData(targetExamples, true)
 	if filterStatusCodeOk {
 		targetExamples = util.FilterStatusCodeOkExamples(targetExamples)
 	}

--- a/lib/expand_url/expand_url.go
+++ b/lib/expand_url/expand_url.go
@@ -34,7 +34,7 @@ func doExpandURL(c *cli.Context) error {
 		return err
 	}
 
-	cache.AttachMetaData(examples)
+	cache.AttachMetaData(examples, true)
 
 	for _, e := range examples {
 		_, err = db.InsertOrUpdateExample(conn, e)

--- a/lib/web/web.go
+++ b/lib/web/web.go
@@ -81,7 +81,7 @@ func recentAddedExamples(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, err.Error())
 		return
 	}
-	cache.AttachMetaData(labeledExamples)
+	cache.AttachMetaData(labeledExamples, false)
 
 	unlabeledExamples, err := db.ReadUnabeledExamples(conn, 100)
 	if err != nil {
@@ -89,7 +89,7 @@ func recentAddedExamples(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, err.Error())
 		return
 	}
-	cache.AttachMetaData(unlabeledExamples)
+	cache.AttachMetaData(unlabeledExamples, false)
 
 	examples := append(labeledExamples, unlabeledExamples...)
 	lightenExamples(examples)
@@ -133,7 +133,7 @@ func getExamplesFromList(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			return nil, err
 		}
-		cache.AttachMetaData(examples)
+		cache.AttachMetaData(examples, false)
 		sort.Sort(sort.Reverse(examples))
 		result := util.RemoveNegativeExamples(examples)
 		return result, nil


### PR DESCRIPTION
新規アイテムがあった際にクロールしにいってしまい、5xxを返すときがあった。5xxになるよりは空でも表示できたほうがいいので変更。