### PR TITLE
Revert "Bump css-loader from 2.1.1 to 3.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3044,79 +3044,22 @@
       }
     },
     "css-loader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.0.0.tgz",
-      "integrity": "sha512-WR6KZuCkFbnMhRrGPlkwAA7SSCtwqPwpyXJAPhotYkYsc0mKU9n/fu5wufy4jl2WhBw9Ia8gUQMIp/1w98DuPw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-2.1.1.tgz",
+      "integrity": "sha512-OcKJU/lt232vl1P9EEDamhoO9iKY3tIjY5GU+XDLblAykTdgs6Ux9P1hTHve8nFKy5KPpOXOsVI/hIwi3841+w==",
       "dev": true,
       "requires": {
-        "camelcase": "^5.3.1",
-        "cssesc": "^3.0.0",
-        "icss-utils": "^4.1.1",
+        "camelcase": "^5.2.0",
+        "icss-utils": "^4.1.0",
         "loader-utils": "^1.2.3",
         "normalize-path": "^3.0.0",
-        "postcss": "^7.0.17",
+        "postcss": "^7.0.14",
         "postcss-modules-extract-imports": "^2.0.0",
-        "postcss-modules-local-by-default": "^3.0.2",
+        "postcss-modules-local-by-default": "^2.0.6",
         "postcss-modules-scope": "^2.1.0",
-        "postcss-modules-values": "^3.0.0",
-        "postcss-value-parser": "^4.0.0",
+        "postcss-modules-values": "^2.0.0",
+        "postcss-value-parser": "^3.3.0",
         "schema-utils": "^1.0.0"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "7.0.17",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-          "integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "postcss-modules-local-by-default": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.2.tgz",
-          "integrity": "sha512-jM/V8eqM4oJ/22j0gx4jrp63GSvDH6v86OqyTHHUvk4/k1vceipZsaymiZ5PvocqZOl5SFHiFJqjs3la0wnfIQ==",
-          "dev": true,
-          "requires": {
-            "icss-utils": "^4.1.1",
-            "postcss": "^7.0.16",
-            "postcss-selector-parser": "^6.0.2",
-            "postcss-value-parser": "^4.0.0"
-          }
-        },
-        "postcss-modules-values": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
-          "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
-          "dev": true,
-          "requires": {
-            "icss-utils": "^4.0.0",
-            "postcss": "^7.0.6"
-          }
-        },
-        "postcss-value-parser": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.0.tgz",
-          "integrity": "sha512-ESPktioptiSUchCKgggAkzdmkgzKfmp0EU8jXH+5kbIUB+unr0Y4CY9SRMvibuvYUBjNh1ACLbxqYNpdTQOteQ==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "css-prefers-color-scheme": {
@@ -6956,17 +6899,6 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "postcss": "^7.0.2"
-      }
-    },
-    "postcss-selector-parser": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
-      "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
-      "dev": true,
-      "requires": {
-        "cssesc": "^3.0.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
       }
     },
     "postcss-url": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/syou6162/go-active-learning-web#readme",
   "devDependencies": {
-    "css-loader": "^3.0.0",
+    "css-loader": "^2.1.1",
     "prettier": "^1.18.2",
     "webpack": "^4.35.0",
     "webpack-cli": "^3.3.5"


### PR DESCRIPTION
Reverts syou6162/go-active-learning-web#65

```
Module build failed (from ./node_modules/css-loader/dist/cjs.js):                                                                                                           friendly-errors 05:33:34
ValidationError: CSS Loader Invalid Options

options should NOT have additional properties

    at validateOptions (/Users/yasuhisa/go/src/github.com/syou6162/go-active-learning-web/node_modules/schema-utils/src/validateOptions.js:32:11)
    at Object.loader (/Users/yasuhisa/go/src/github.com/syou6162/go-active-learning-web/node_modules/css-loader/dist/index.js:34:28)
```

ref: https://vue-loader.vuejs.org/guide/css-modules.html#usage