### PR TITLE
Revert "Bump bootstrap-vue from 2.0.0-rc.21 to 2.0.0-rc.27"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2200,15 +2200,16 @@
       "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
     },
     "bootstrap-vue": {
-      "version": "2.0.0-rc.27",
-      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.0.0-rc.27.tgz",
-      "integrity": "sha512-gXdpt2IsKbmC3SU0bf/RgldWwgrXK7G47yslOtkk4OA1z6fOzb2orM2vU5L8NCNZQomYax9LapRucv+8PByfdA==",
+      "version": "2.0.0-rc.21",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.0.0-rc.21.tgz",
+      "integrity": "sha512-cGMKpk60xik+VhgQ8hUiRVaysOBv+4QhBLcegzsl31LNyFmIJPaAJyqrO/Nz3m8AkCEMkTECRNk2ZLm1RQE9dQ==",
       "requires": {
         "@nuxt/opencollective": "^0.2.2",
         "bootstrap": "^4.3.1",
+        "core-js": ">=2.6.5 <3.0.0",
         "popper.js": "^1.15.0",
-        "portal-vue": "^2.1.5",
-        "vue-functional-data-merge": "^3.1.0"
+        "portal-vue": "^2.1.4",
+        "vue-functional-data-merge": "^2.0.7"
       }
     },
     "boxen": {
@@ -6241,9 +6242,9 @@
       "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
     },
     "portal-vue": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.5.tgz",
-      "integrity": "sha512-vZmdMn0mOo7puvxoMQ5zju6S29aFD+9yygJxyWQtPaMXS9xunAeoYdnx6yzfL9J8HD8pMZYgSieEIbioAKhrSQ=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.4.tgz",
+      "integrity": "sha512-Mr2h+RvoOOGHS7N0E3QPP+UQMt1OhSjQ7eMSGTXqkLiO0AjGEDw2x4kzmHATsZfDqQumiaYSDRzlUP2By3lvsA=="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -8462,9 +8463,9 @@
       "integrity": "sha512-DS8Q+WFT3i7nS0aZ/NMmTPf2yhbtlXhj4QEZmY69au/BshsGzGjC6dXaniZaPQlErP3J3Sv1HtQ4RVrXaUTkxA=="
     },
     "vue-functional-data-merge": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vue-functional-data-merge/-/vue-functional-data-merge-3.1.0.tgz",
-      "integrity": "sha512-leT4kdJVQyeZNY1kmnS1xiUlQ9z1B/kdBFCILIjYYQDqZgLqCLa0UhjSSeRX6c3mUe6U5qYeM8LrEqkHJ1B4LA=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/vue-functional-data-merge/-/vue-functional-data-merge-2.0.7.tgz",
+      "integrity": "sha512-pvLc+H+x2prwBj/uSEIITyxjz/7ZUVVK8uYbrYMmhDvMXnzh9OvQvVEwcOSBQjsubd4Eq41/CSJaWzy4hemMNQ=="
     },
     "vue-hot-reload-api": {
       "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@nuxtjs/proxy": "^1.3.3",
     "aws-amplify": "^1.1.28",
     "aws-amplify-vue": "^0.2.12",
-    "bootstrap-vue": "^2.0.0-rc.27",
+    "bootstrap-vue": "^2.0.0-rc.21",
     "cross-env": "^5.2.0",
     "cssnano": "^4.1.10",
     "date-fns": "^2.0.0-beta.3",


### PR DESCRIPTION
This reverts commit d93f7c3af9aebd21d4a2551ba3d23460d44e7e73.

- ref: https://github.com/syou6162/go-active-learning-web/pull/93
- `Cannot read property 'install' of undefined`