### PR TITLE
amplifyのバージョンを固定

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -36,8 +36,8 @@ const nuxtConfig: Configuration = {
   */
   plugins: [
     { src: "@/plugins/filters.ts", ssr: true },
-    { src: "@/plugins/lazyload.ts", ssr: false },
-    { src: "@/plugins/amplify.ts", ssr: false }
+    { src: "@/plugins/lazyload.ts", mode: 'client' },
+    { src: "@/plugins/amplify.ts", mode: 'client' },
   ],
 
   /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,26 +5,14 @@
   "requires": true,
   "dependencies": {
     "@aws-amplify/auth": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-2.1.2.tgz",
-      "integrity": "sha512-ZDpqSzHAJUqp2uMpy4oorv//mOT6hBEoOqbTU0Hi5qGAbj7DJNakBFOAGfLD6vS8G9mq/aX6YSm3EOV8x2RahQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-2.1.0.tgz",
+      "integrity": "sha512-FxmPuxGW9s7OCd/yHUihHbGtiW/H0wZivMdRwilS8uDjklou+lTHYTiNF6UYBoZP3TVLkmBYykzqThEtEMT27A==",
       "requires": {
-        "@aws-amplify/cache": "^2.1.2",
-        "@aws-amplify/core": "^2.2.1",
-        "amazon-cognito-identity-js": "^3.2.1",
+        "@aws-amplify/cache": "^2.1.0",
+        "@aws-amplify/core": "^2.1.0",
+        "amazon-cognito-identity-js": "^3.2.0",
         "crypto-js": "^3.1.9-1"
-      },
-      "dependencies": {
-        "@aws-amplify/core": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-2.2.1.tgz",
-          "integrity": "sha512-gjqwpdN9bccC05LCPoKEWWNVMcWc8SPuG/PhBW9CxicX72FljLMP4ae9A21zymz63auUtp4qUbHcc4D9JW/EpA==",
-          "requires": {
-            "aws-sdk": "2.518.0",
-            "url": "^0.11.0",
-            "zen-observable": "^0.8.6"
-          }
-        }
       }
     },
     "@aws-amplify/cache": {
@@ -48,13 +36,12 @@
       }
     },
     "@aws-amplify/core": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-2.2.1.tgz",
-      "integrity": "sha512-gjqwpdN9bccC05LCPoKEWWNVMcWc8SPuG/PhBW9CxicX72FljLMP4ae9A21zymz63auUtp4qUbHcc4D9JW/EpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-UgoFtDd7MZfpPg7cNuLkP01j9GCQ9V/mE92STKzu9EB8XKcd0sYMKunibXoOeMbbfwsD8X4Pnwp+3/KdP1LWwQ==",
       "requires": {
         "aws-sdk": "2.518.0",
-        "url": "^0.11.0",
-        "zen-observable": "^0.8.6"
+        "url": "^0.11.0"
       }
     },
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "webpack-cli": "^3.3.10"
   },
   "dependencies": {
-    "@aws-amplify/auth": "^2.1.2",
-    "@aws-amplify/core": "^2.2.1",
+    "@aws-amplify/auth": "^2.1.0",
+    "@aws-amplify/core": "^2.1.0",
     "@nuxt/types": "^0.5.9",
     "@nuxt/typescript-runtime": "^0.3.5",
     "@nuxtjs/axios": "^5.9.0",


### PR DESCRIPTION
```
      Error: Amplify has not been configured correctly.
            This error is typically caused by one of the following scenarios:

            1. Make sure you're passing the awsconfig object to Amplify.configure() in your app's entry point
                See https://aws-amplify.github.io/docs/js/authentication#configure-your-app for more information
            
            2. There might be multiple conflicting versions of aws-amplify or amplify packages in your node_modules.
                Try deleting your node_modules folder and reinstalling the dependencies with `yarn install`
```