### PR TITLE
fix aws-amplify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,65 +4,75 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@aws-amplify/auth": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-3.2.1.tgz",
-      "integrity": "sha512-AaygX0huO7Mcq4s1wZ191wiS9H2CHp1L0yvfTvHT+Iuvl6cat1AkIj7cIJSDS+ST6s5sP0YuD80QLSvkueAKVg==",
+    "@aws-amplify/analytics": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-3.1.5.tgz",
+      "integrity": "sha512-ASRxG6o1rRZD4uswedXErLAF0BJDlsUsKT9lWK0cXc6WPpHuwmW8Hrnakq4H2DpzQolx+Gv/28ZfyEJcfnIkFg==",
       "requires": {
-        "@aws-amplify/cache": "^3.1.4",
-        "@aws-amplify/core": "^3.2.1",
-        "amazon-cognito-identity-js": "^4.2.0",
+        "@aws-amplify/cache": "^3.1.5",
+        "@aws-amplify/core": "^3.2.2",
+        "@aws-sdk/client-firehose": "1.0.0-beta.3",
+        "@aws-sdk/client-kinesis": "1.0.0-beta.3",
+        "@aws-sdk/client-personalize-events": "1.0.0-beta.3",
+        "@aws-sdk/client-pinpoint": "1.0.0-beta.3",
+        "uuid": "^3.2.1"
+      }
+    },
+    "@aws-amplify/api": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-3.1.5.tgz",
+      "integrity": "sha512-rPTLH1dc8wLuZzDaSJK7wkgt3NLTya2QU1UaONDDUfcd4Mnj+O6PQJzZXV1qsDFq44P/26iF1uAeASm7WPaU8Q==",
+      "requires": {
+        "@aws-amplify/api-graphql": "^1.0.7",
+        "@aws-amplify/api-rest": "^1.0.7"
+      }
+    },
+    "@aws-amplify/api-graphql": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-1.0.7.tgz",
+      "integrity": "sha512-cXFS1QZApmRGWdf3+CBDEZM01grFxh7Eid4sSciKcqVt26B/FEubPP+uO0H2yGMj9645EKJfpdbGUaEvQMz1yQ==",
+      "requires": {
+        "@aws-amplify/api-rest": "^1.0.7",
+        "@aws-amplify/auth": "^3.2.2",
+        "@aws-amplify/cache": "^3.1.5",
+        "@aws-amplify/core": "^3.2.2",
+        "graphql": "14.0.0",
+        "uuid": "^3.2.1",
+        "zen-observable-ts": "0.8.19"
+      }
+    },
+    "@aws-amplify/api-rest": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-1.0.7.tgz",
+      "integrity": "sha512-j2qt8riuiPnzN+0bpleifq1PFTP3AwJfr/jUeiGucog3nXawNT2q8VU5HguRABckRZ3YgGU5xoB2JOM8WFAayA==",
+      "requires": {
+        "@aws-amplify/core": "^3.2.2",
+        "axios": "^0.19.0"
+      }
+    },
+    "@aws-amplify/auth": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-3.2.2.tgz",
+      "integrity": "sha512-tztc7VWrch0Wu3/6ifdzFu9zpHg2Cy2rvxCGG+XPpK0BR5R1tts2WpotEKJ8ebcKD8M/CIZug/Bt3u6rpQE2nw==",
+      "requires": {
+        "@aws-amplify/cache": "^3.1.5",
+        "@aws-amplify/core": "^3.2.2",
+        "amazon-cognito-identity-js": "^4.2.1",
         "crypto-js": "^3.3.0"
-      },
-      "dependencies": {
-        "@aws-amplify/core": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-3.2.1.tgz",
-          "integrity": "sha512-uOCzZ8ULT6zjKEJRWwJGHmQYl2CXKxNw6owMuHDDl3e9w7xTLVr22Ky7J1glMmrVX9n7oLzfqbP55WDRX3ydrg==",
-          "requires": {
-            "@aws-crypto/sha256-js": "1.0.0-alpha.0",
-            "@aws-sdk/client-cognito-identity": "1.0.0-beta.3",
-            "@aws-sdk/credential-provider-cognito-identity": "1.0.0-beta.3",
-            "@aws-sdk/node-http-handler": "1.0.0-beta.2",
-            "@aws-sdk/types": "1.0.0-beta.2",
-            "@aws-sdk/util-hex-encoding": "1.0.0-beta.2",
-            "@aws-sdk/util-user-agent-browser": "1.0.0-beta.2",
-            "url": "^0.11.0",
-            "zen-observable-ts": "0.8.19"
-          }
-        }
       }
     },
     "@aws-amplify/cache": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-3.1.4.tgz",
-      "integrity": "sha512-6Eke07pZeSqlb8IrsB8cJFzY8fRxBxt1tm7UihFPnu8O3Y+q5gWZacHajwjp29sqJGWpF8YRCfKHmz49zpROeQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-3.1.5.tgz",
+      "integrity": "sha512-Wu805g/c2WKTaUhIBZp4Ht02b6CgBoyqN2Eu8OEklvbK4ANZwlbC7jf+f4dUv2oaR+6pIFbqS68sxej92puAdQ==",
       "requires": {
-        "@aws-amplify/core": "^3.2.1"
-      },
-      "dependencies": {
-        "@aws-amplify/core": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-3.2.1.tgz",
-          "integrity": "sha512-uOCzZ8ULT6zjKEJRWwJGHmQYl2CXKxNw6owMuHDDl3e9w7xTLVr22Ky7J1glMmrVX9n7oLzfqbP55WDRX3ydrg==",
-          "requires": {
-            "@aws-crypto/sha256-js": "1.0.0-alpha.0",
-            "@aws-sdk/client-cognito-identity": "1.0.0-beta.3",
-            "@aws-sdk/credential-provider-cognito-identity": "1.0.0-beta.3",
-            "@aws-sdk/node-http-handler": "1.0.0-beta.2",
-            "@aws-sdk/types": "1.0.0-beta.2",
-            "@aws-sdk/util-hex-encoding": "1.0.0-beta.2",
-            "@aws-sdk/util-user-agent-browser": "1.0.0-beta.2",
-            "url": "^0.11.0",
-            "zen-observable-ts": "0.8.19"
-          }
-        }
+        "@aws-amplify/core": "^3.2.2"
       }
     },
     "@aws-amplify/core": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-3.2.1.tgz",
-      "integrity": "sha512-uOCzZ8ULT6zjKEJRWwJGHmQYl2CXKxNw6owMuHDDl3e9w7xTLVr22Ky7J1glMmrVX9n7oLzfqbP55WDRX3ydrg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-3.2.2.tgz",
+      "integrity": "sha512-ebb/zyQ/LUTyC/T+boU77Ivh8w4x5fhY+7Ded8YVkuYh5lSEm5/k/TZY2c/V1hzswXQKUEsVenJk1lrQYKiySw==",
       "requires": {
         "@aws-crypto/sha256-js": "1.0.0-alpha.0",
         "@aws-sdk/client-cognito-identity": "1.0.0-beta.3",
@@ -73,6 +83,97 @@
         "@aws-sdk/util-user-agent-browser": "1.0.0-beta.2",
         "url": "^0.11.0",
         "zen-observable-ts": "0.8.19"
+      }
+    },
+    "@aws-amplify/datastore": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-2.0.6.tgz",
+      "integrity": "sha512-cS23POnbTVaqD/8mFtLODeOD1hQTG+mFrJ9XI0i9veLt8fv6/e5PNXOagODNTrz79S6PJbtY16UsxTg2DZ3EhA==",
+      "requires": {
+        "@aws-amplify/api": "^3.1.5",
+        "@aws-amplify/core": "^3.2.2",
+        "@aws-amplify/pubsub": "^3.0.6",
+        "idb": "4.0.4",
+        "immer": "6.0.1",
+        "uuid": "3.3.2",
+        "zen-observable-ts": "0.8.19",
+        "zen-push": "0.2.1"
+      }
+    },
+    "@aws-amplify/interactions": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-3.1.5.tgz",
+      "integrity": "sha512-jfSTkXi2tAv0MTg4ylxqpubIYY3BPVEc760sJJtcmZVYuCIf0IH6hvDMiJg3ZiptMnTFIJDgkD7ljTIPsV7MRw==",
+      "requires": {
+        "@aws-amplify/core": "^3.2.2",
+        "@aws-sdk/client-lex-runtime-service": "1.0.0-beta.3"
+      }
+    },
+    "@aws-amplify/predictions": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-3.1.5.tgz",
+      "integrity": "sha512-zt8YRy79m8O/AGVkxL4cy7SrpjCLpbklD+z9PMN1fNQk09iXnCq/ezjuM9M33yGgCUmbtSiWm4pjLrisMwlIxQ==",
+      "requires": {
+        "@aws-amplify/core": "^3.2.2",
+        "@aws-amplify/storage": "^3.1.5",
+        "@aws-sdk/client-comprehend": "1.0.0-beta.3",
+        "@aws-sdk/client-polly": "1.0.0-beta.3",
+        "@aws-sdk/client-rekognition": "1.0.0-beta.3",
+        "@aws-sdk/client-textract": "1.0.0-beta.3",
+        "@aws-sdk/client-translate": "1.0.0-beta.3",
+        "@aws-sdk/eventstream-marshaller": "1.0.0-beta.2",
+        "@aws-sdk/util-utf8-node": "1.0.0-beta.2",
+        "uuid": "^3.2.1"
+      }
+    },
+    "@aws-amplify/pubsub": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-3.0.6.tgz",
+      "integrity": "sha512-T2OS4fOcpHalp+9PeRL1dsCj4mjVJfoTJTSCgXA27PNPzCFgXcZkc8Y75bjGmdfCKgdg+GBV5uQP88bKleGg+A==",
+      "requires": {
+        "@aws-amplify/auth": "^3.2.2",
+        "@aws-amplify/cache": "^3.1.5",
+        "@aws-amplify/core": "^3.2.2",
+        "graphql": "14.0.0",
+        "paho-mqtt": "^1.1.0",
+        "uuid": "^3.2.1",
+        "zen-observable-ts": "0.8.19"
+      }
+    },
+    "@aws-amplify/storage": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-3.1.5.tgz",
+      "integrity": "sha512-6JZ+zlT1WMU8oSB3ZtjsnFQKZncEPURAk323RkAWet6sbyI6+PL/ImFqzkMkMVyjw6Vp3G0Nf7/y/MvsI1Aymg==",
+      "requires": {
+        "@aws-amplify/core": "^3.2.2",
+        "@aws-sdk/client-s3": "1.0.0-beta.3",
+        "@aws-sdk/s3-request-presigner": "1.0.0-beta.3",
+        "@aws-sdk/util-create-request": "1.0.0-beta.3",
+        "@aws-sdk/util-format-url": "1.0.0-beta.2",
+        "axios": "^0.19.0",
+        "events": "^3.1.0",
+        "sinon": "^7.5.0"
+      }
+    },
+    "@aws-amplify/ui": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-2.0.2.tgz",
+      "integrity": "sha512-OLdZmUCVK29+JV8PrkgVPjg+GIFtBnNjhC0JSRgrps+ynOFkibMQQPKeFXlTYtlukuCuepCelPSkjxvhcLq2ZA=="
+    },
+    "@aws-amplify/xr": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-2.1.5.tgz",
+      "integrity": "sha512-AexJZEB2noFOhztiYeKsZQFRDBa6fQRIOXtP9QzNx/dIfohtEtMNzIF7A8NZc4Tdb4ZaqXePlzAXHFWw3F+82A==",
+      "requires": {
+        "@aws-amplify/core": "^3.2.2"
+      }
+    },
+    "@aws-crypto/crc32": {
+      "version": "1.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-1.0.0-alpha.0.tgz",
+      "integrity": "sha512-n4OJttn49liBR0CVdK7dAvkTaP8jLiRRekdA0wunTEELIIwjC4c60YODADbqR2Hug4dtzQ6huJTgyFeHIaYPHg==",
+      "requires": {
+        "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/ie11-detection": {
@@ -124,6 +225,23 @@
         "tslib": "^1.8.0"
       }
     },
+    "@aws-sdk/chunked-blob-reader": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-1.0.0-beta.2.tgz",
+      "integrity": "sha512-7BnvA1PsCrnwzfBEfyt6C7v4q14ulmIGAKKFGgqQH2B3WS6JlOg6yzpdV+Yd1OUlTfDLl+8sr/JRbMX1igKtiA==",
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/chunked-blob-reader-native": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-1.0.0-beta.2.tgz",
+      "integrity": "sha512-0GqkWkxKX7sgROVaAHjn+LxRRWzadA/C16wshAnV8ERP4mYJpbFAOovEDoDTlQHK98i/WmtuN15WX5rt7cEyug==",
+      "requires": {
+        "@aws-sdk/util-base64-browser": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
     "@aws-sdk/client-cognito-identity": {
       "version": "1.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-1.0.0-beta.3.tgz",
@@ -162,6 +280,479 @@
         "@aws-sdk/util-utf8-browser": "^1.0.0-beta.2",
         "@aws-sdk/util-utf8-node": "^1.0.0-beta.2",
         "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/client-comprehend": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-comprehend/-/client-comprehend-1.0.0-beta.3.tgz",
+      "integrity": "sha512-OvosOySzKPKXFRYJSiehHvxLuzilcMWArhP1UEx23KpOXS4MSwQj6OZtXVelQoDKnFjkXeUtVoMZ6wFhAxdxrA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+        "@aws-sdk/config-resolver": "^1.0.0-beta.2",
+        "@aws-sdk/credential-provider-node": "^1.0.0-beta.2",
+        "@aws-sdk/fetch-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/hash-node": "^1.0.0-beta.2",
+        "@aws-sdk/invalid-dependency": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-content-length": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-host-header": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-retry": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-serde": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-signing": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-stack": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-user-agent": "^1.0.0-beta.2",
+        "@aws-sdk/node-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/protocol-http": "^1.0.0-beta.2",
+        "@aws-sdk/region-provider": "^1.0.0-beta.2",
+        "@aws-sdk/smithy-client": "^1.0.0-beta.3",
+        "@aws-sdk/stream-collector-browser": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-native": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-node": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-browser": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-node": "^1.0.0-beta.2",
+        "tslib": "^1.8.0",
+        "uuid": "^7.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+        }
+      }
+    },
+    "@aws-sdk/client-firehose": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-firehose/-/client-firehose-1.0.0-beta.3.tgz",
+      "integrity": "sha512-9HWdKpfP8v8wh1i0J44Tnlz4iMXdRMovYPTqxXHIzpFjvbmrKsNiIL80fH58DzBbQIc1eB1x65154gjrfzi4vw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+        "@aws-sdk/config-resolver": "^1.0.0-beta.2",
+        "@aws-sdk/credential-provider-node": "^1.0.0-beta.2",
+        "@aws-sdk/fetch-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/hash-node": "^1.0.0-beta.2",
+        "@aws-sdk/invalid-dependency": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-content-length": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-host-header": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-retry": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-serde": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-signing": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-stack": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-user-agent": "^1.0.0-beta.2",
+        "@aws-sdk/node-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/protocol-http": "^1.0.0-beta.2",
+        "@aws-sdk/region-provider": "^1.0.0-beta.2",
+        "@aws-sdk/smithy-client": "^1.0.0-beta.3",
+        "@aws-sdk/stream-collector-browser": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-native": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-node": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-browser": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-node": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/client-kinesis": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis/-/client-kinesis-1.0.0-beta.3.tgz",
+      "integrity": "sha512-Ahqv7wYESJ+2zmqE/1WnLsxGh4p+CSaSTytYMZG2TtYXlgSBvVrN/kSChKQuLl6KjEw6gdDYDCEvYK5W+zb6qw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+        "@aws-sdk/config-resolver": "^1.0.0-beta.2",
+        "@aws-sdk/credential-provider-node": "^1.0.0-beta.2",
+        "@aws-sdk/eventstream-serde-browser": "^1.0.0-beta.2",
+        "@aws-sdk/eventstream-serde-config-resolver": "^1.0.0-beta.2",
+        "@aws-sdk/eventstream-serde-node": "^1.0.0-beta.2",
+        "@aws-sdk/fetch-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/hash-node": "^1.0.0-beta.2",
+        "@aws-sdk/invalid-dependency": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-content-length": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-host-header": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-retry": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-serde": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-signing": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-stack": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-user-agent": "^1.0.0-beta.2",
+        "@aws-sdk/node-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/protocol-http": "^1.0.0-beta.2",
+        "@aws-sdk/region-provider": "^1.0.0-beta.2",
+        "@aws-sdk/smithy-client": "^1.0.0-beta.3",
+        "@aws-sdk/stream-collector-browser": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-native": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-node": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-browser": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-node": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/client-lex-runtime-service": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lex-runtime-service/-/client-lex-runtime-service-1.0.0-beta.3.tgz",
+      "integrity": "sha512-muTrUs30rFNCsVPdpCvWzvqyWSIUpkgjUwEeY5eilU6SQUS6vETJZdreSpNDIHOClksEcT8EN28QHLNu1L52GQ==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+        "@aws-sdk/config-resolver": "^1.0.0-beta.2",
+        "@aws-sdk/credential-provider-node": "^1.0.0-beta.2",
+        "@aws-sdk/fetch-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/hash-node": "^1.0.0-beta.2",
+        "@aws-sdk/invalid-dependency": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-content-length": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-host-header": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-retry": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-serde": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-signing": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-stack": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-user-agent": "^1.0.0-beta.2",
+        "@aws-sdk/node-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/protocol-http": "^1.0.0-beta.2",
+        "@aws-sdk/region-provider": "^1.0.0-beta.2",
+        "@aws-sdk/smithy-client": "^1.0.0-beta.3",
+        "@aws-sdk/stream-collector-browser": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-native": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-node": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-browser": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-node": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/client-personalize-events": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-personalize-events/-/client-personalize-events-1.0.0-beta.3.tgz",
+      "integrity": "sha512-co6EqRm1LIhYmsKqKEpb+pFaHWTGGggf/MnUlIXVfs5GSFGs/PdiWAm4t6gEYM1Rq5nM1XJ41JlRYCJhJSa04A==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+        "@aws-sdk/config-resolver": "^1.0.0-beta.2",
+        "@aws-sdk/credential-provider-node": "^1.0.0-beta.2",
+        "@aws-sdk/fetch-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/hash-node": "^1.0.0-beta.2",
+        "@aws-sdk/invalid-dependency": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-content-length": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-host-header": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-retry": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-serde": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-signing": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-stack": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-user-agent": "^1.0.0-beta.2",
+        "@aws-sdk/node-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/protocol-http": "^1.0.0-beta.2",
+        "@aws-sdk/region-provider": "^1.0.0-beta.2",
+        "@aws-sdk/smithy-client": "^1.0.0-beta.3",
+        "@aws-sdk/stream-collector-browser": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-native": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-node": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-browser": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-node": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/client-pinpoint": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-pinpoint/-/client-pinpoint-1.0.0-beta.3.tgz",
+      "integrity": "sha512-EGzlM0a9Mh0vzTb/r5ESO86InZXUILAjc3djT7rjtfQS+GzxUeYgBzPt3cM2FDkOOprZy1XqI3VSHf/jTh9pRw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+        "@aws-sdk/config-resolver": "^1.0.0-beta.2",
+        "@aws-sdk/credential-provider-node": "^1.0.0-beta.2",
+        "@aws-sdk/fetch-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/hash-node": "^1.0.0-beta.2",
+        "@aws-sdk/invalid-dependency": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-content-length": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-host-header": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-retry": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-serde": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-signing": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-stack": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-user-agent": "^1.0.0-beta.2",
+        "@aws-sdk/node-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/protocol-http": "^1.0.0-beta.2",
+        "@aws-sdk/region-provider": "^1.0.0-beta.2",
+        "@aws-sdk/smithy-client": "^1.0.0-beta.3",
+        "@aws-sdk/stream-collector-browser": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-native": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-node": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-browser": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-node": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/client-polly": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-polly/-/client-polly-1.0.0-beta.3.tgz",
+      "integrity": "sha512-tk42EU+CGXtejmfl4u6+bFCOy3K2WXN2nsvufNWr9238FpGRHV4SKV3qPIxsN5IkE41j/XTDhnWWh5s354lTtg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+        "@aws-sdk/config-resolver": "^1.0.0-beta.2",
+        "@aws-sdk/credential-provider-node": "^1.0.0-beta.2",
+        "@aws-sdk/fetch-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/hash-node": "^1.0.0-beta.2",
+        "@aws-sdk/invalid-dependency": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-content-length": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-host-header": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-retry": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-serde": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-signing": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-stack": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-user-agent": "^1.0.0-beta.2",
+        "@aws-sdk/node-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/protocol-http": "^1.0.0-beta.2",
+        "@aws-sdk/region-provider": "^1.0.0-beta.2",
+        "@aws-sdk/smithy-client": "^1.0.0-beta.3",
+        "@aws-sdk/stream-collector-browser": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-native": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-node": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-browser": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-node": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/client-rekognition": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-rekognition/-/client-rekognition-1.0.0-beta.3.tgz",
+      "integrity": "sha512-buQl+H32Ikzk4driSpCzy0G6nvHKvKV1gWh4nin2vNKoy+83n/H4H49jd8qCUZHzjgWiRE4aUFRAyQ8IuA2Gtw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+        "@aws-sdk/config-resolver": "^1.0.0-beta.2",
+        "@aws-sdk/credential-provider-node": "^1.0.0-beta.2",
+        "@aws-sdk/fetch-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/hash-node": "^1.0.0-beta.2",
+        "@aws-sdk/invalid-dependency": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-content-length": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-host-header": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-retry": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-serde": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-signing": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-stack": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-user-agent": "^1.0.0-beta.2",
+        "@aws-sdk/node-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/protocol-http": "^1.0.0-beta.2",
+        "@aws-sdk/region-provider": "^1.0.0-beta.2",
+        "@aws-sdk/smithy-client": "^1.0.0-beta.3",
+        "@aws-sdk/stream-collector-browser": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-native": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-node": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-browser": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-node": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/client-s3": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-1.0.0-beta.3.tgz",
+      "integrity": "sha512-Vs9NOEMZhbfKQDbsenKUZYZ7HOqTtTxBg+Cc+ZhXJ+iVxjR9f1TFLiutJoKVUU4PuRo+4cI/nuVqyhSLKsF8KQ==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+        "@aws-sdk/config-resolver": "^1.0.0-beta.2",
+        "@aws-sdk/credential-provider-node": "^1.0.0-beta.2",
+        "@aws-sdk/eventstream-serde-browser": "^1.0.0-beta.2",
+        "@aws-sdk/eventstream-serde-config-resolver": "^1.0.0-beta.2",
+        "@aws-sdk/eventstream-serde-node": "^1.0.0-beta.2",
+        "@aws-sdk/fetch-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/hash-blob-browser": "^1.0.0-beta.2",
+        "@aws-sdk/hash-node": "^1.0.0-beta.2",
+        "@aws-sdk/hash-stream-node": "^1.0.0-beta.2",
+        "@aws-sdk/invalid-dependency": "^1.0.0-beta.2",
+        "@aws-sdk/md5-js": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-apply-body-checksum": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-bucket-endpoint": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-content-length": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-expect-continue": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-host-header": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-location-constraint": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-retry": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-sdk-s3": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-serde": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-signing": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-ssec": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-stack": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-user-agent": "^1.0.0-beta.2",
+        "@aws-sdk/node-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/protocol-http": "^1.0.0-beta.2",
+        "@aws-sdk/region-provider": "^1.0.0-beta.2",
+        "@aws-sdk/smithy-client": "^1.0.0-beta.3",
+        "@aws-sdk/stream-collector-browser": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-native": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-node": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-browser": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-node": "^1.0.0-beta.2",
+        "@aws-sdk/xml-builder": "^1.0.0-beta.2",
+        "fast-xml-parser": "^3.16.0",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/client-textract": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-textract/-/client-textract-1.0.0-beta.3.tgz",
+      "integrity": "sha512-Q+LsxqLrgGT/oVYEWEkaocsv7SS4rFGi11Uxw1yvF130sm4rT34gplKCnL6GDaMzrJ1e1F10codmoPhsQaXa2g==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+        "@aws-sdk/config-resolver": "^1.0.0-beta.2",
+        "@aws-sdk/credential-provider-node": "^1.0.0-beta.2",
+        "@aws-sdk/fetch-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/hash-node": "^1.0.0-beta.2",
+        "@aws-sdk/invalid-dependency": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-content-length": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-host-header": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-retry": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-serde": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-signing": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-stack": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-user-agent": "^1.0.0-beta.2",
+        "@aws-sdk/node-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/protocol-http": "^1.0.0-beta.2",
+        "@aws-sdk/region-provider": "^1.0.0-beta.2",
+        "@aws-sdk/smithy-client": "^1.0.0-beta.3",
+        "@aws-sdk/stream-collector-browser": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-native": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-node": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-browser": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-node": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/client-translate": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-translate/-/client-translate-1.0.0-beta.3.tgz",
+      "integrity": "sha512-D6sPIKHBRAiaStxPiOD2e4P86SK68/g3zagDOaHvLSRQpD4CMOtslWtV3dreXOPyqhjFKs4P2fRSa6prChb3nQ==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
+        "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+        "@aws-sdk/config-resolver": "^1.0.0-beta.2",
+        "@aws-sdk/credential-provider-node": "^1.0.0-beta.2",
+        "@aws-sdk/fetch-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/hash-node": "^1.0.0-beta.2",
+        "@aws-sdk/invalid-dependency": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-content-length": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-host-header": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-retry": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-serde": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-signing": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-stack": "^1.0.0-beta.2",
+        "@aws-sdk/middleware-user-agent": "^1.0.0-beta.2",
+        "@aws-sdk/node-http-handler": "^1.0.0-beta.2",
+        "@aws-sdk/protocol-http": "^1.0.0-beta.2",
+        "@aws-sdk/region-provider": "^1.0.0-beta.2",
+        "@aws-sdk/smithy-client": "^1.0.0-beta.3",
+        "@aws-sdk/stream-collector-browser": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-native": "^1.0.0-beta.2",
+        "@aws-sdk/stream-collector-node": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-browser": "^1.0.0-beta.2",
+        "@aws-sdk/url-parser-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-base64-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-body-length-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-user-agent-node": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-browser": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-node": "^1.0.0-beta.2",
+        "tslib": "^1.8.0",
+        "uuid": "^7.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+        }
       }
     },
     "@aws-sdk/config-resolver": {
@@ -242,6 +833,46 @@
         "tslib": "^1.8.0"
       }
     },
+    "@aws-sdk/eventstream-marshaller": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-1.0.0-beta.2.tgz",
+      "integrity": "sha512-B0eZJOoX0hdW0AByZ/b1GqFicE3fKqGDLSuRboO5a/HQoj3sfjXNRAEqYc+g3ZV+84gddZM3AlqsrQveRIi3cg==",
+      "requires": {
+        "@aws-crypto/crc32": "^1.0.0-alpha.0",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "@aws-sdk/util-hex-encoding": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/eventstream-serde-browser": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-1.0.0-beta.2.tgz",
+      "integrity": "sha512-7M7Qsy8kaXf2/hnq9IltVyLD6lO5XjFpOBpKgK7TE66AI7hcJ49qMbtG2ig1/0ZI6LkDd03MjoDgwk8Y2McLow==",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-1.0.0-beta.2.tgz",
+      "integrity": "sha512-+JE18UeBJc1h4VEl0wkfh22u9fsOYTxv9BViLumAJukMnbds716lzXQdMSsK0opEjpOf5Md9XCVcfR1tqKX8tQ==",
+      "requires": {
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/eventstream-serde-node": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-1.0.0-beta.2.tgz",
+      "integrity": "sha512-I6NBaiu28wHEmAWCtbeOsc5prpXgdepw5kCSaYMSJIcnw5sZ7EQksrPPXfBvAGsTRO+AcO/x1ZqgQJ8+9F/IOQ==",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
     "@aws-sdk/fetch-http-handler": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-1.0.0-beta.2.tgz",
@@ -253,6 +884,17 @@
         "tslib": "^1.8.0"
       }
     },
+    "@aws-sdk/hash-blob-browser": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-1.0.0-beta.2.tgz",
+      "integrity": "sha512-r1sDcEcwhZHBWlEGO0j2paTi8X4S1+d3GgsSaXPy0PHY36I2YWypnHk5V9FFiSXLmz7Tf7ymjD465I9kUQBYGA==",
+      "requires": {
+        "@aws-sdk/chunked-blob-reader": "^1.0.0-beta.2",
+        "@aws-sdk/chunked-blob-reader-native": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
     "@aws-sdk/hash-node": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-1.0.0-beta.2.tgz",
@@ -260,6 +902,15 @@
       "requires": {
         "@aws-sdk/types": "^1.0.0-beta.2",
         "@aws-sdk/util-buffer-from": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/hash-stream-node": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-1.0.0-beta.2.tgz",
+      "integrity": "sha512-qGq3OJaH+SfRCfbDL97kcz3DxjAqnnoKZvayYZNlrHnyHSTbeKanurZNraqm8rV5mQsu8BYoir0GA7OsCvNOMw==",
+      "requires": {
+        "@aws-sdk/types": "^1.0.0-beta.2",
         "tslib": "^1.8.0"
       }
     },
@@ -279,10 +930,62 @@
         "tslib": "^1.8.0"
       }
     },
+    "@aws-sdk/md5-js": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-1.0.0-beta.2.tgz",
+      "integrity": "sha512-guLLNbdJDKS8VYPEXLUufaa9F3EfUQl4vCIZkS1aKk2Jf+TxYDlJ1jDUf7vDG45Nim5w3MWmU209W0h4I+Wxvg==",
+      "requires": {
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "@aws-sdk/util-utf8-browser": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-apply-body-checksum": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-1.0.0-beta.2.tgz",
+      "integrity": "sha512-7heI9KDoWXomN8h2qaMB5v0y7z02aRL4OxYQ8YleViybnpWW0OfdeHsBQqxus0prz6aP2OJnPimUnajsuDdyzQ==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "^1.0.0-beta.2",
+        "@aws-sdk/protocol-http": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-bucket-endpoint": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-1.0.0-beta.2.tgz",
+      "integrity": "sha512-Odk+KKgc1gfRVRc/Mgtp+eNbZBNXNzqa8x3OKJS8c3qu0xqGXvvWwgEgylGukG+pCEKRB7/mKHCDSbzxkRi0dg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
     "@aws-sdk/middleware-content-length": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-1.0.0-beta.2.tgz",
       "integrity": "sha512-J97/qV6vm2/18nGPKmSEkx18sMBn6+1fydW/zvrc83kHZ/bqV6Z+Ku8Kiy0QtekatHkdkbBWiWWINEtQJYMjRA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-expect-continue": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-1.0.0-beta.2.tgz",
+      "integrity": "sha512-VXyN5xza8AfF4aHNXgSUh8svcZPuZgh/fhvCT1sim0atVD4lOraTEPE/fa1mtDugpBmiI/RnP4+sXDKegGiYGw==",
+      "requires": {
+        "@aws-sdk/middleware-header-default": "^1.0.0-beta.2",
+        "@aws-sdk/protocol-http": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-header-default": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-1.0.0-beta.2.tgz",
+      "integrity": "sha512-m2TRSJCAQXlcepKc6rFmpek4VH6A1GiqPeyhkKXjCAixZv4D0mjgbAwcOqmfSKehT/fxO0apttItGSyWuOlJ8Q==",
       "requires": {
         "@aws-sdk/protocol-http": "^1.0.0-beta.2",
         "@aws-sdk/types": "^1.0.0-beta.2",
@@ -299,6 +1002,15 @@
         "tslib": "^1.8.0"
       }
     },
+    "@aws-sdk/middleware-location-constraint": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-1.0.0-beta.2.tgz",
+      "integrity": "sha512-IFCvft910cnlj8Twx8SBGQOkW92MTj26C8p/k1/dQTB+P5bRbwYTYJiZNShWjqRw2WYOY/TjLcB5nVBz5bekLQ==",
+      "requires": {
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
     "@aws-sdk/middleware-retry": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-1.0.0-beta.2.tgz",
@@ -306,6 +1018,14 @@
       "requires": {
         "@aws-sdk/service-error-classification": "^1.0.0-beta.2",
         "@aws-sdk/types": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-sdk-s3": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-1.0.0-beta.2.tgz",
+      "integrity": "sha512-NnWor2EnVEFNL247nb6P7b5/VAJJzJuPJvP7cpBoBxVLIYJ2VjzKQzwT5W+ZiSn31dLJvraPzb/ybMq6JOr3qw==",
+      "requires": {
         "tslib": "^1.8.0"
       }
     },
@@ -325,6 +1045,15 @@
       "requires": {
         "@aws-sdk/protocol-http": "^1.0.0-beta.2",
         "@aws-sdk/signature-v4": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-ssec": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-1.0.0-beta.2.tgz",
+      "integrity": "sha512-TBXUNUuWmtP/hEvxr79IHBKCJbFXjuldo9B/ug9AkCIXcJyHK+8ajnbeTAF4ha2ELJ5hS7URKMF34/Na9Ta/Fg==",
+      "requires": {
         "@aws-sdk/types": "^1.0.0-beta.2",
         "tslib": "^1.8.0"
       }
@@ -405,6 +1134,18 @@
         "@aws-sdk/property-provider": "^1.0.0-beta.2",
         "@aws-sdk/shared-ini-file-loader": "^1.0.0-beta.2",
         "@aws-sdk/types": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/s3-request-presigner": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-1.0.0-beta.3.tgz",
+      "integrity": "sha512-vsIuwcuyxS3NrMEwT1pebZKTq8gOwHb6rR2DCw8JX5ya/si4X/TixNkFzV2L0BYFUuQ6RG8nhc2dkif26IJwEg==",
+      "requires": {
+        "@aws-sdk/signature-v4": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "@aws-sdk/util-create-request": "^1.0.0-beta.3",
+        "@aws-sdk/util-format-url": "^1.0.0-beta.2",
         "tslib": "^1.8.0"
       }
     },
@@ -539,6 +1280,27 @@
         "tslib": "^1.8.0"
       }
     },
+    "@aws-sdk/util-create-request": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-1.0.0-beta.3.tgz",
+      "integrity": "sha512-g+zzOrRf6ivS/eQVKyIbWQZLn1zoH3RiEW/aWCqa3zsJmtSp3Qav9SfUREXEPD91KQF7Q4BY7vdYHJN8kd/OmA==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "^1.0.0-beta.2",
+        "@aws-sdk/smithy-client": "^1.0.0-beta.3",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-format-url": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-1.0.0-beta.2.tgz",
+      "integrity": "sha512-AL+ksiJfDm/TPkPuT1PR9OkZfKnGAsE4SidO891PpSoCxbRL5peJflacrwmJ9R6XL76icYfzC3sUTAJwMt2rTQ==",
+      "requires": {
+        "@aws-sdk/querystring-builder": "^1.0.0-beta.2",
+        "@aws-sdk/types": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
     "@aws-sdk/util-hex-encoding": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-1.0.0-beta.2.tgz",
@@ -595,6 +1357,14 @@
       "integrity": "sha512-lrQi1kMauHPSU7E7XLvF9Qim5HyDkh6ey0YsGbcx6SMitQzYxyqKk3Y5xsziYIUKdJvvYtoJTbA3Gcg2uQivag==",
       "requires": {
         "@aws-sdk/util-buffer-from": "^1.0.0-beta.2",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/xml-builder": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-1.0.0-beta.2.tgz",
+      "integrity": "sha512-MfsGwmL8r+DSXnhUjFwkeoz4tTQ9MrqoBG5o1GXcF8IA5bloaQoYT7NLdRfCphe+Uos9yGT6uyzGgbfTO5rz5g==",
+      "requires": {
         "tslib": "^1.8.0"
       }
     },
@@ -3416,6 +4186,45 @@
         "@sentry/cli": "^1.49.0"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
+      "integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "requires": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -3428,19 +4237,6 @@
       "requires": {
         "@types/browserslist": "*",
         "postcss": "7.x.x"
-      }
-    },
-    "@types/babel__core": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
-      "integrity": "sha512-tTnhWszAqvXnhW7m5jQU9PomXSiKXk2sFxpahXvI20SZKu9ylPi8WtIxueZ6ehDWikPT0jeFujMj3X4ZHuf3Tg==",
-      "dev": true,
-      "requires": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
       }
     },
     "@types/babel__generator": {
@@ -4148,9 +4944,9 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "amazon-cognito-identity-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-4.2.0.tgz",
-      "integrity": "sha512-w9WHth5khfv3PDKG8fSKKnoxmcQviR4OwmgrCK65QscpG5yPeGmZ6eWVfIaPGT11f2M9iBoLDylttEa0fJtntw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-4.2.1.tgz",
+      "integrity": "sha512-0sdZSLHU5cPNNNI6LLdarflOZSoFjiz7nMJPsrZxD5duw0u9GxGn1fTx+qjrN/6FSS527iIR9FYpB8+FySuCdA==",
       "requires": {
         "buffer": "4.9.1",
         "crypto-js": "^3.3.0",
@@ -4254,6 +5050,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
     },
     "array-unique": {
       "version": "0.3.2",
@@ -4374,6 +5175,25 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "aws-amplify": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-3.0.6.tgz",
+      "integrity": "sha512-s6dKoLOTFt6j4/wJeESOBpDB/x+e/yiq14wX/qwkm4p0dn4YsluiFfix0oNfEoSha7xWEy6JgKL/akm4ZB4m2w==",
+      "requires": {
+        "@aws-amplify/analytics": "^3.1.5",
+        "@aws-amplify/api": "^3.1.5",
+        "@aws-amplify/auth": "^3.2.2",
+        "@aws-amplify/cache": "^3.1.5",
+        "@aws-amplify/core": "^3.2.2",
+        "@aws-amplify/datastore": "^2.0.6",
+        "@aws-amplify/interactions": "^3.1.5",
+        "@aws-amplify/predictions": "^3.1.5",
+        "@aws-amplify/pubsub": "^3.0.6",
+        "@aws-amplify/storage": "^3.1.5",
+        "@aws-amplify/ui": "^2.0.2",
+        "@aws-amplify/xr": "^2.1.5"
       }
     },
     "axios": {
@@ -7416,6 +8236,11 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
+    "events": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
+      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
+    },
     "eventsource-polyfill": {
       "version": "0.9.6",
       "resolved": "https://registry.npmjs.org/eventsource-polyfill/-/eventsource-polyfill-0.9.6.tgz",
@@ -7688,6 +8513,11 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fast-xml-parser": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.16.0.tgz",
+      "integrity": "sha512-U+bpScacfgnfNfIKlWHDu4u6rtOaCyxhblOLJ8sZPkhsjgGqdZmVPBhdOyvdMGCDt8CsAv+cssOP3NzQptNt2w=="
     },
     "figgy-pudding": {
       "version": "3.5.1",
@@ -8151,6 +8981,14 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
+    "graphql": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.0.0.tgz",
+      "integrity": "sha512-HGVcnO6B25YZcSt6ZsH6/N+XkYuPA7yMqJmlJ4JWxWlS4Tr8SHI56R1Ocs8Eor7V7joEZPRXPDH8RRdll1w44Q==",
+      "requires": {
+        "iterall": "^1.2.2"
+      }
+    },
     "gzip-size": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
@@ -8478,6 +9316,11 @@
         "postcss": "^7.0.14"
       }
     },
+    "idb": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-4.0.4.tgz",
+      "integrity": "sha512-ZYsaBSNub2yAnjvmRKudQlMIPqZQIefAOwNIPeXC+RLIeXYFc0UNQqONKNuQeBNf8oBOV5L75yJ9zFISjHVj4g=="
+    },
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
@@ -8492,6 +9335,11 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
       "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
+    },
+    "immer": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-6.0.1.tgz",
+      "integrity": "sha512-oXwigCKgznQywsXi1VgrqgWbQEU3wievNCVc4Fcwky6mwXU6YHj6JuYp0WEM/B1EphkqsLr0x18lm5OiuemPcA=="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -8868,6 +9716,11 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
+    "iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
+    },
     "jest-worker": {
       "version": "25.2.6",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
@@ -8958,6 +9811,11 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "just-extend": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA=="
     },
     "kind-of": {
       "version": "6.0.2",
@@ -9122,6 +9980,11 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/logrocket-vuex/-/logrocket-vuex-0.0.3.tgz",
       "integrity": "sha1-4R1l04Twyf2scvmEQ2zAOK3z25A="
+    },
+    "lolex": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -9522,6 +10385,41 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
+    "nise": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
+      "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+      "requires": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^5.0.1",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "lolex": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+          "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
     "no-case": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
@@ -9894,6 +10792,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
       "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+    },
+    "paho-mqtt": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/paho-mqtt/-/paho-mqtt-1.1.0.tgz",
+      "integrity": "sha512-KPbL9KAB0ASvhSDbOrZBaccXS+/s7/LIofbPyERww8hM5Ko71GUJQ6Nmg0BWqj8phAIT8zdf/Sd/RftHU9i2HA=="
     },
     "pako": {
       "version": "1.0.11",
@@ -11483,6 +12386,27 @@
         }
       }
     },
+    "sinon": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.3",
+        "diff": "^3.5.0",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+        }
+      }
+    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -12291,6 +13215,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
       "version": "0.5.2",
@@ -13347,6 +14276,21 @@
       "requires": {
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
+      }
+    },
+    "zen-push": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/zen-push/-/zen-push-0.2.1.tgz",
+      "integrity": "sha512-Qv4qvc8ZIue51B/0zmeIMxpIGDVhz4GhJALBvnKs/FRa2T7jy4Ori9wFwaHVt0zWV7MIFglKAHbgnVxVTw7U1w==",
+      "requires": {
+        "zen-observable": "^0.7.0"
+      },
+      "dependencies": {
+        "zen-observable": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.7.1.tgz",
+          "integrity": "sha512-OI6VMSe0yeqaouIXtedC+F55Sr6r9ppS7+wTbSexkYdHbdt4ctTuPNXP/rwm7GTVI63YBc+EBT0b0tl7YnJLRg=="
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,6 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
-    "@aws-amplify/auth": "^3.2.1",
-    "@aws-amplify/core": "^3.2.1",
     "@nuxt/types": "^0.7.1",
     "@nuxt/typescript-runtime": "^0.4.2",
     "@nuxtjs/axios": "^5.9.7",
@@ -43,6 +41,7 @@
     "@nuxtjs/sentry": "^4.0.0",
     "@ungap/url-search-params": "^0.1.4",
     "autolinker": "^3.14.0",
+    "aws-amplify": "^3.0.6",
     "bootstrap-vue": "^2.10.1",
     "cross-env": "^7.0.2",
     "cssnano": "^4.1.10",

--- a/pages/admin/annotation/examples/index.vue
+++ b/pages/admin/annotation/examples/index.vue
@@ -24,7 +24,7 @@
 import { Component, Vue } from 'vue-property-decorator';
 import Example from '~/components/Example.vue';
 import { NewExample } from '~/plugins/util';
-import Auth from '@aws-amplify/auth';
+import { Auth } from 'aws-amplify';
 
 @Component({
   components: {

--- a/pages/admin/annotation/tweets/index.vue
+++ b/pages/admin/annotation/tweets/index.vue
@@ -24,7 +24,7 @@
 import { Component, Vue } from 'vue-property-decorator';
 import Example from '~/models/Example'
 import { NewExample } from '~/plugins/util';
-import Auth from '@aws-amplify/auth';
+import { Auth } from 'aws-amplify';
 
 @Component({
   components: {

--- a/pages/admin/index.vue
+++ b/pages/admin/index.vue
@@ -28,8 +28,8 @@
     </button>
     <div id="annotation-links">
       <ul>
-        <li><a href="annotation/examples">Exampleのアノテーション</a></li>
-        <li><a href="annotation/tweets">Tweetのアノテーション</a></li>
+        <li><a href="/admin/annotation/examples">Exampleのアノテーション</a></li>
+        <li><a href="/admin/annotation/tweets">Tweetのアノテーション</a></li>
       </ul>
     </div>
   </div>

--- a/pages/example/_id.vue
+++ b/pages/example/_id.vue
@@ -202,7 +202,7 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import Auth from '@aws-amplify/auth';
+import { Auth } from 'aws-amplify';
 import * as Sentry from '@sentry/browser';
 import Autolinker from 'autolinker';
 import Example from '~/components/Example.vue';

--- a/pages/list/_ListName.vue
+++ b/pages/list/_ListName.vue
@@ -32,7 +32,7 @@
 import { Component, Vue } from 'vue-property-decorator';
 import Example from '~/models/Example'
 
-import Auth from '@aws-amplify/auth';
+import { Auth } from 'aws-amplify';
 import { NewExample } from '~/plugins/util';
 
 const keywordsByListname: { [key: string]: string[] } = {

--- a/pages/list/twitter.vue
+++ b/pages/list/twitter.vue
@@ -76,7 +76,7 @@ import { Component, Vue } from 'vue-property-decorator';
 import Autolinker from 'autolinker';
 import Example from '~/models/Example'
 
-import Auth from '@aws-amplify/auth';
+import { Auth } from 'aws-amplify';
 import { NewExample } from '~/plugins/util';
 
 @Component({

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -32,7 +32,7 @@
 import { Component, Vue, Watch } from 'vue-property-decorator';
 import Example from '~/models/Example'
 import URLSearchParams from '@ungap/url-search-params'
-import Auth from '@aws-amplify/auth';
+import { Auth } from 'aws-amplify';
 import { NewExample } from '~/plugins/util';
 
 @Component({

--- a/plugins/amplify.ts
+++ b/plugins/amplify.ts
@@ -1,5 +1,4 @@
-import Amplify from '@aws-amplify/core';
-import Auth from '@aws-amplify/auth';
+import Amplify, { Auth } from 'aws-amplify';
 
 Amplify.configure({
   Auth: {


### PR DESCRIPTION
不要なライブラリのインストールを避けるために @aws-amplify/auth と @aws-amplify/core をインストールしていたが、バージョンの食い合わせを考えるのが難しいので、諦めてamplifyは全部入りにしておく...