### PR TITLE
ReferringTweetをコンポーネントに分割

### DIFF
--- a/components/ExampleDetail/ReferringTweet.spec.ts
+++ b/components/ExampleDetail/ReferringTweet.spec.ts
@@ -1,0 +1,55 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import { BListGroupItem } from 'bootstrap-vue'
+import ReferringTweet from '~/components/ExampleDetail/ReferringTweet.vue'
+
+const localVue = createLocalVue();
+localVue.component('b-list-group-item', BListGroupItem)
+
+const tweet = {
+  ExampleId: 21805423,
+
+  CreatedAt: "2020-08-26T03:13:06Z",
+  IdStr: "1298458422581448704",
+  FullText: "【イベント情報】先月開催された「Embulk &amp; DigDag Online Meetup 2020」のレポート記事を公開しました。\nEmbulkとDigdagをプロダクション環境で利用している事例や、Embulk開発者による発表が盛り沢山です！是非ご一読下さい。\nhttps://t.co/gdtRuoyJtY",
+  FavoriteCount: 6,
+  RetweetCount: 4,
+  Lang: "ja",
+
+  ScreenName: "trocco_jp",
+  Name: "データ分析基盤の総合支援SaaS「trocco(トロッコ)」",
+  ProfileImageUrl: "https://pbs.twimg.com/profile_images/1051692644311556096/WmDcCj4Z_normal.jpg",
+  Label: 1,
+  Score: 0.4894515842007917
+}
+
+describe('ReferringTweet', () => {
+  test('個別事例ページの中のtweetが正しく表示できる', () => {
+    const wrapper = shallowMount(ReferringTweet, {
+      localVue,
+      propsData: {
+        tweet: tweet,
+        isAdmin: false
+      }
+    })
+    expect(wrapper.exists()).toBeTruthy()
+    expect(wrapper.find('.tweet-item').exists()).toBe(true)
+    expect(wrapper.find('.tweet-retweet-count').text()).toBe(`${tweet.RetweetCount} RT`)
+    expect(wrapper.find('.tweet-favorite-count').text()).toBe(`${tweet.FavoriteCount} Fav`)
+
+    expect(wrapper.element).toMatchSnapshot()
+  })
+
+  test('adminの場合はアノテーションボタンが表示される', () => {
+    const wrapper = shallowMount(ReferringTweet, {
+      localVue,
+      propsData: {
+        tweet: tweet,
+        isAdmin: true
+      }
+    })
+    expect(wrapper.exists()).toBeTruthy()
+    expect(wrapper.find('tweet-annotate-buttons-stub').exists()).toBe(true)
+
+    expect(wrapper.element).toMatchSnapshot()
+  })
+})

--- a/components/ExampleDetail/ReferringTweet.vue
+++ b/components/ExampleDetail/ReferringTweet.vue
@@ -1,0 +1,76 @@
+<template>
+  <b-list-group-item class="tweet-item">
+    <img
+      v-if="tweet.ProfileImageUrl"
+      :src="tweet.ProfileImageUrl"
+      class="tweet-full-text-icon-img"
+      onerror="this.src='/img/twitter_icon.png'"
+    >
+    <div class="tweet-screen-name-and-full-text-container">
+      <a
+        :href="'https://twitter.com/' + tweet.ScreenName + '/status/' + tweet.IdStr"
+        target="_blank"
+        rel="noopener"
+      >@{{ tweet.ScreenName }}</a>
+      <span v-html="fullTextWithLinks(tweet.FullText)" />
+      <div class="tweet-footer">
+        <span class="tweet-retweet-count">{{ tweet.RetweetCount }} RT</span>, <span class="tweet-favorite-count"> {{ tweet.FavoriteCount }} Fav</span>
+        <span class="tweet-created-at">{{ tweet.CreatedAt }}</span>
+      </div>
+    </div>
+    <tweet-annotate-buttons
+      v-if="isAdmin"
+      :tweet="tweet"
+    />
+  </b-list-group-item>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Autolinker, AutolinkerConfig } from 'autolinker';
+import Tweet from '~/models/Tweet'
+import TweetAnnotateButtons from '~/components/TweetAnnotateButtons.vue'
+
+@Component({
+  components: {
+    TweetAnnotateButtons
+  }
+})
+export default class ReferringTweet extends Vue {
+  @Prop()
+  tweet!: Tweet
+
+  @Prop({required: true, default: false})
+  isAdmin!: Boolean
+  
+  fullTextWithLinks(fullText: string): string {
+    const opts: AutolinkerConfig = { 
+      mention: 'twitter',
+      hashtag: 'twitter'
+    };
+    return Autolinker.link(fullText, opts);
+  }
+}
+</script>
+
+<style scoped>
+.tweet-item {
+  padding: 10px 10px;
+}
+.tweet-screen-name-and-full-text-container {
+  overflow: hidden;
+}
+.tweets-count, .tweet-retweet-count, .tweet-favorite-count {
+  color: #ff4166;
+}
+.tweet-full-text-icon-img {
+  float: left;
+  width: 32px;
+  height: 32px;
+  margin: 0 10px 0 0;
+}
+.tweet-created-at {
+  color: #999;
+  float: right;
+}
+</style>

--- a/components/ExampleDetail/__snapshots__/ReferringTweet.spec.ts.snap
+++ b/components/ExampleDetail/__snapshots__/ReferringTweet.spec.ts.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReferringTweet adminの場合はアノテーションボタンが表示される 1`] = `
+<b-list-group-item-stub
+  class="tweet-item"
+  tag="div"
+  target="_self"
+>
+  <img
+    class="tweet-full-text-icon-img"
+    onerror="this.src='/img/twitter_icon.png'"
+    src="https://pbs.twimg.com/profile_images/1051692644311556096/WmDcCj4Z_normal.jpg"
+  />
+   
+  <div
+    class="tweet-screen-name-and-full-text-container"
+  >
+    <a
+      href="https://twitter.com/trocco_jp/status/1298458422581448704"
+      rel="noopener"
+      target="_blank"
+    >
+      @trocco_jp
+    </a>
+     
+    <span>
+      【イベント情報】先月開催された「Embulk & DigDag Online Meetup 2020」のレポート記事を公開しました。
+EmbulkとDigdagをプロダクション環境で利用している事例や、Embulk開発者による発表が盛り沢山です！是非ご一読下さい。
+
+      <a
+        href="https://t.co/gdtRuoyJtY"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        t.co/gdtRuoyJtY
+      </a>
+    </span>
+     
+    <div
+      class="tweet-footer"
+    >
+      <span
+        class="tweet-retweet-count"
+      >
+        4 RT
+      </span>
+      , 
+      <span
+        class="tweet-favorite-count"
+      >
+         6 Fav
+      </span>
+       
+      <span
+        class="tweet-created-at"
+      >
+        2020-08-26T03:13:06Z
+      </span>
+    </div>
+  </div>
+   
+  <tweet-annotate-buttons-stub
+    tweet="[object Object]"
+  />
+</b-list-group-item-stub>
+`;
+
+exports[`ReferringTweet 個別事例ページの中のtweetが正しく表示できる 1`] = `
+<b-list-group-item-stub
+  class="tweet-item"
+  tag="div"
+  target="_self"
+>
+  <img
+    class="tweet-full-text-icon-img"
+    onerror="this.src='/img/twitter_icon.png'"
+    src="https://pbs.twimg.com/profile_images/1051692644311556096/WmDcCj4Z_normal.jpg"
+  />
+   
+  <div
+    class="tweet-screen-name-and-full-text-container"
+  >
+    <a
+      href="https://twitter.com/trocco_jp/status/1298458422581448704"
+      rel="noopener"
+      target="_blank"
+    >
+      @trocco_jp
+    </a>
+     
+    <span>
+      【イベント情報】先月開催された「Embulk & DigDag Online Meetup 2020」のレポート記事を公開しました。
+EmbulkとDigdagをプロダクション環境で利用している事例や、Embulk開発者による発表が盛り沢山です！是非ご一読下さい。
+
+      <a
+        href="https://t.co/gdtRuoyJtY"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        t.co/gdtRuoyJtY
+      </a>
+    </span>
+     
+    <div
+      class="tweet-footer"
+    >
+      <span
+        class="tweet-retweet-count"
+      >
+        4 RT
+      </span>
+      , 
+      <span
+        class="tweet-favorite-count"
+      >
+         6 Fav
+      </span>
+       
+      <span
+        class="tweet-created-at"
+      >
+        2020-08-26T03:13:06Z
+      </span>
+    </div>
+  </div>
+   
+  <!---->
+</b-list-group-item-stub>
+`;

--- a/pages/example/__snapshots__/_id.spec.ts.snap
+++ b/pages/example/__snapshots__/_id.spec.ts.snap
@@ -154,68 +154,10 @@ exports[`ExamplePage Twitterの項目が出ている 1`] = `
     <b-list-group-stub
       tag="div"
     >
-      <b-list-group-item-stub
-        class="tweet-item"
-        tag="div"
-        target="_self"
-      >
-        <img
-          class="tweet-full-text-icon-img"
-          onerror="this.src='/img/twitter_icon.png'"
-          src="https://pbs.twimg.com/profile_images/1051692644311556096/WmDcCj4Z_normal.jpg"
-        />
-         
-        <div
-          class="tweet-screen-name-and-full-text-container"
-        >
-          <a
-            href="https://twitter.com/trocco_jp/status/1298458422581448704"
-            rel="noopener"
-            target="_blank"
-          >
-            @trocco_jp
-          </a>
-           
-          <span>
-            【イベント情報】先月開催された「Embulk & DigDag Online Meetup 2020」のレポート記事を公開しました。
-EmbulkとDigdagをプロダクション環境で利用している事例や、Embulk開発者による発表が盛り沢山です！是非ご一読下さい。
-
-            <a
-              href="https://t.co/gdtRuoyJtY"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              t.co/gdtRuoyJtY
-            </a>
-          </span>
-           
-          <div
-            class="tweet-footer"
-          >
-            <span
-              class="tweet-retweet-count"
-            >
-              4 RT
-            </span>
-            , 
-            <span
-              class="tweet-favorite-count"
-            >
-               6 Fav
-            </span>
-             
-            <span
-              class="tweet-created-at"
-            >
-              2020-08-26T03:13:06Z
-            </span>
-          </div>
-        </div>
-         
-        <tweet-annotate-buttons-stub
-          tweet="[object Object]"
-        />
-      </b-list-group-item-stub>
+      <referring-tweet-stub
+        isadmin="true"
+        tweet="[object Object]"
+      />
     </b-list-group-stub>
   </div>
    
@@ -441,68 +383,10 @@ exports[`ExamplePage はてなブックマークの項目が出ている 1`] = `
     <b-list-group-stub
       tag="div"
     >
-      <b-list-group-item-stub
-        class="tweet-item"
-        tag="div"
-        target="_self"
-      >
-        <img
-          class="tweet-full-text-icon-img"
-          onerror="this.src='/img/twitter_icon.png'"
-          src="https://pbs.twimg.com/profile_images/1051692644311556096/WmDcCj4Z_normal.jpg"
-        />
-         
-        <div
-          class="tweet-screen-name-and-full-text-container"
-        >
-          <a
-            href="https://twitter.com/trocco_jp/status/1298458422581448704"
-            rel="noopener"
-            target="_blank"
-          >
-            @trocco_jp
-          </a>
-           
-          <span>
-            【イベント情報】先月開催された「Embulk & DigDag Online Meetup 2020」のレポート記事を公開しました。
-EmbulkとDigdagをプロダクション環境で利用している事例や、Embulk開発者による発表が盛り沢山です！是非ご一読下さい。
-
-            <a
-              href="https://t.co/gdtRuoyJtY"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              t.co/gdtRuoyJtY
-            </a>
-          </span>
-           
-          <div
-            class="tweet-footer"
-          >
-            <span
-              class="tweet-retweet-count"
-            >
-              4 RT
-            </span>
-            , 
-            <span
-              class="tweet-favorite-count"
-            >
-               6 Fav
-            </span>
-             
-            <span
-              class="tweet-created-at"
-            >
-              2020-08-26T03:13:06Z
-            </span>
-          </div>
-        </div>
-         
-        <tweet-annotate-buttons-stub
-          tweet="[object Object]"
-        />
-      </b-list-group-item-stub>
+      <referring-tweet-stub
+        isadmin="true"
+        tweet="[object Object]"
+      />
     </b-list-group-stub>
   </div>
    
@@ -726,66 +610,9 @@ exports[`ExamplePage#Amplify amplifyを通っていないときはアノテー�
     <b-list-group-stub
       tag="div"
     >
-      <b-list-group-item-stub
-        class="tweet-item"
-        tag="div"
-        target="_self"
-      >
-        <img
-          class="tweet-full-text-icon-img"
-          onerror="this.src='/img/twitter_icon.png'"
-          src="https://pbs.twimg.com/profile_images/1051692644311556096/WmDcCj4Z_normal.jpg"
-        />
-         
-        <div
-          class="tweet-screen-name-and-full-text-container"
-        >
-          <a
-            href="https://twitter.com/trocco_jp/status/1298458422581448704"
-            rel="noopener"
-            target="_blank"
-          >
-            @trocco_jp
-          </a>
-           
-          <span>
-            【イベント情報】先月開催された「Embulk & DigDag Online Meetup 2020」のレポート記事を公開しました。
-EmbulkとDigdagをプロダクション環境で利用している事例や、Embulk開発者による発表が盛り沢山です！是非ご一読下さい。
-
-            <a
-              href="https://t.co/gdtRuoyJtY"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              t.co/gdtRuoyJtY
-            </a>
-          </span>
-           
-          <div
-            class="tweet-footer"
-          >
-            <span
-              class="tweet-retweet-count"
-            >
-              4 RT
-            </span>
-            , 
-            <span
-              class="tweet-favorite-count"
-            >
-               6 Fav
-            </span>
-             
-            <span
-              class="tweet-created-at"
-            >
-              2020-08-26T03:13:06Z
-            </span>
-          </div>
-        </div>
-         
-        <!---->
-      </b-list-group-item-stub>
+      <referring-tweet-stub
+        tweet="[object Object]"
+      />
     </b-list-group-stub>
   </div>
    
@@ -1011,68 +838,10 @@ exports[`ExamplePage#Amplify amplifyを通っていないときはアノテー�
     <b-list-group-stub
       tag="div"
     >
-      <b-list-group-item-stub
-        class="tweet-item"
-        tag="div"
-        target="_self"
-      >
-        <img
-          class="tweet-full-text-icon-img"
-          onerror="this.src='/img/twitter_icon.png'"
-          src="https://pbs.twimg.com/profile_images/1051692644311556096/WmDcCj4Z_normal.jpg"
-        />
-         
-        <div
-          class="tweet-screen-name-and-full-text-container"
-        >
-          <a
-            href="https://twitter.com/trocco_jp/status/1298458422581448704"
-            rel="noopener"
-            target="_blank"
-          >
-            @trocco_jp
-          </a>
-           
-          <span>
-            【イベント情報】先月開催された「Embulk & DigDag Online Meetup 2020」のレポート記事を公開しました。
-EmbulkとDigdagをプロダクション環境で利用している事例や、Embulk開発者による発表が盛り沢山です！是非ご一読下さい。
-
-            <a
-              href="https://t.co/gdtRuoyJtY"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              t.co/gdtRuoyJtY
-            </a>
-          </span>
-           
-          <div
-            class="tweet-footer"
-          >
-            <span
-              class="tweet-retweet-count"
-            >
-              4 RT
-            </span>
-            , 
-            <span
-              class="tweet-favorite-count"
-            >
-               6 Fav
-            </span>
-             
-            <span
-              class="tweet-created-at"
-            >
-              2020-08-26T03:13:06Z
-            </span>
-          </div>
-        </div>
-         
-        <tweet-annotate-buttons-stub
-          tweet="[object Object]"
-        />
-      </b-list-group-item-stub>
+      <referring-tweet-stub
+        isadmin="true"
+        tweet="[object Object]"
+      />
     </b-list-group-stub>
   </div>
    
@@ -1298,68 +1067,10 @@ exports[`ExamplePage#Amplify amplifyを通っているときはアノテーシ�
     <b-list-group-stub
       tag="div"
     >
-      <b-list-group-item-stub
-        class="tweet-item"
-        tag="div"
-        target="_self"
-      >
-        <img
-          class="tweet-full-text-icon-img"
-          onerror="this.src='/img/twitter_icon.png'"
-          src="https://pbs.twimg.com/profile_images/1051692644311556096/WmDcCj4Z_normal.jpg"
-        />
-         
-        <div
-          class="tweet-screen-name-and-full-text-container"
-        >
-          <a
-            href="https://twitter.com/trocco_jp/status/1298458422581448704"
-            rel="noopener"
-            target="_blank"
-          >
-            @trocco_jp
-          </a>
-           
-          <span>
-            【イベント情報】先月開催された「Embulk & DigDag Online Meetup 2020」のレポート記事を公開しました。
-EmbulkとDigdagをプロダクション環境で利用している事例や、Embulk開発者による発表が盛り沢山です！是非ご一読下さい。
-
-            <a
-              href="https://t.co/gdtRuoyJtY"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              t.co/gdtRuoyJtY
-            </a>
-          </span>
-           
-          <div
-            class="tweet-footer"
-          >
-            <span
-              class="tweet-retweet-count"
-            >
-              4 RT
-            </span>
-            , 
-            <span
-              class="tweet-favorite-count"
-            >
-               6 Fav
-            </span>
-             
-            <span
-              class="tweet-created-at"
-            >
-              2020-08-26T03:13:06Z
-            </span>
-          </div>
-        </div>
-         
-        <tweet-annotate-buttons-stub
-          tweet="[object Object]"
-        />
-      </b-list-group-item-stub>
+      <referring-tweet-stub
+        isadmin="true"
+        tweet="[object Object]"
+      />
     </b-list-group-stub>
   </div>
    

--- a/pages/example/_id.spec.ts
+++ b/pages/example/_id.spec.ts
@@ -207,7 +207,6 @@ describe('ExamplePage#Amplify', () => {
       isAdmin: true
     })
     expect(wrapper.find('annotate-buttons-stub').exists()).toBe(true)
-    expect(wrapper.find('tweet-annotate-buttons-stub').exists()).toBe(true)
     expect(wrapper.element).toMatchSnapshot()
   })
   test('amplifyを通っているときはアノテーションボタンを出す', async () => {
@@ -234,7 +233,6 @@ describe('ExamplePage#Amplify', () => {
     })
     expect(wrapper.exists()).toBeTruthy()
     expect(wrapper.find('annotate-buttons-stub').exists()).toBe(true)
-    expect(wrapper.find('tweet-annotate-buttons-stub').exists()).toBe(true)
     expect(wrapper.element).toMatchSnapshot()
   })
 })

--- a/pages/example/_id.vue
+++ b/pages/example/_id.vue
@@ -90,34 +90,12 @@
         Referring Tweets
       </h2>
       <b-list-group>
-        <b-list-group-item
+        <referring-tweet
           v-for="t in tweetsWithPositiveLabelOrPositiveScore.slice(0, 9)"
           :key="t.IdStr"
-          class="tweet-item"
-        >
-          <img
-            v-if="t.ProfileImageUrl"
-            :src="t.ProfileImageUrl"
-            class="tweet-full-text-icon-img"
-            onerror="this.src='/img/twitter_icon.png'"
-          >
-          <div class="tweet-screen-name-and-full-text-container">
-            <a
-              :href="'https://twitter.com/' + t.ScreenName + '/status/' + t.IdStr"
-              target="_blank"
-              rel="noopener"
-            >@{{ t.ScreenName }}</a>
-            <span v-html="fullTextWithLinks(t.FullText)" />
-            <div class="tweet-footer">
-              <span class="tweet-retweet-count">{{ t.RetweetCount }} RT</span>, <span class="tweet-favorite-count"> {{ t.FavoriteCount }} Fav</span>
-              <span class="tweet-created-at">{{ t.CreatedAt }}</span>
-            </div>
-          </div>
-          <tweet-annotate-buttons
-            v-if="isAdmin"
-            :tweet="t"
-          />
-        </b-list-group-item>
+          :tweet="t"
+          :is-admin="isAdmin"
+        />
       </b-list-group>
     </div>
     <div
@@ -219,14 +197,14 @@ import { NewExample } from '~/plugins/util';
 import HatenaBookmarkIcon from '~/components/HatenaBookmarkIcon.vue'
 import TwitterIcon from '~/components/TwitterIcon.vue'
 import AnnotateButtons from '~/components/AnnotateButtons.vue'
-import TweetAnnotateButtons from '~/components/TweetAnnotateButtons.vue'
+import ReferringTweet from '~/components/ExampleDetail/ReferringTweet.vue'
 
 @Component({
   components: {
     HatenaBookmarkIcon,
     TwitterIcon,
     AnnotateButtons,
-    TweetAnnotateButtons,
+    ReferringTweet,
   },
   filters: {
     getTitle(example: Example, length: number, omission: string): string {
@@ -389,7 +367,7 @@ export default class ExamplePage extends Vue {
   width: 16px;
   height: 16px;
 }
-.tweet-item, .hatena-bookmark-item, .similar-example {
+.hatena-bookmark-item, .similar-example {
   padding: 10px 10px;
 }
 .hatena-bookmark-link {
@@ -401,7 +379,7 @@ export default class ExamplePage extends Vue {
   height: 32px;
   margin: 0 10px 0 0;
 }
-.tweet-screen-name-and-full-text-container, .hatena-bookmark-user-link-and-comment-container, .similar-example-title-container {
+.hatena-bookmark-user-link-and-comment-container, .similar-example-title-container {
   overflow: hidden;
 }
 .hatena-bookmark-user-link {
@@ -412,19 +390,6 @@ export default class ExamplePage extends Vue {
 }
 .hatena-bookmark-timestamp {
   display: block;
-  color: #999;
-  float: right;
-}
-.tweets-count, .tweet-retweet-count, .tweet-favorite-count {
-  color: #ff4166;
-}
-.tweet-full-text-icon-img {
-  float: left;
-  width: 32px;
-  height: 32px;
-  margin: 0 10px 0 0;
-}
-.tweet-created-at {
   color: #999;
   float: right;
 }


### PR DESCRIPTION
個別の事例ページが大きくなってしまっているので、分割して扱いやすくする。