### PR TITLE
go 1.16以降はGO111MODULEはディフォルトでonなので指定しないように変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ defaults: &defaults
   environment:
     GOPATH: /
     GOCACHE: /.cache/go-build
-    GO111MODULE: "on"
     PGHOST: 127.0.0.1
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 COMMIT ?= $$(git describe --always 2>/dev/null)
 COVERAGE = coverage.out
-export GO111MODULE := on
 
 all: build
 


### PR DESCRIPTION
- [Go のモジュール管理【バージョン 1.16 改訂版】](https://zenn.dev/spiegel/articles/20210223-go-module-aware-mode)